### PR TITLE
Fix onChange to send incremental data

### DIFF
--- a/packages/document/src/components/Editor/Editor.tsx
+++ b/packages/document/src/components/Editor/Editor.tsx
@@ -89,9 +89,8 @@ export default defineComponent({
 
         quill.on("text-change", (delta, _old, source) => {
           if (source === "user" && !isApplyingExternal && props.onChange) {
-            // 直接使用 getContents，不需要过滤
-            const contents = quill.getContents();
-            props.onChange(contents);
+            // 传递增量变更
+            props.onChange(delta);
           }
         });
 


### PR DESCRIPTION
Change `Editor`'s `onChange` callback to pass incremental changes (delta) instead of full content.

---
<a href="https://cursor.com/background-agent?bcId=bc-73f644c4-2416-4e66-86a8-c27355157b09">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-73f644c4-2416-4e66-86a8-c27355157b09">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>